### PR TITLE
Add support for arbitrary characters in object names using hex codes

### DIFF
--- a/source/flbase.h
+++ b/source/flbase.h
@@ -380,7 +380,10 @@ static void __setup__(t_classid classid) { 	    	\
 
 
 // generate name of dsp/non-dsp setup function
-#if FLEXT_SYS == FLEXT_SYS_PD || FLEXT_SYS == FLEXT_SYS_MAX
+#if defined(FLEXT_USE_HEX_SETUP_NAME) && defined(FLEXT_SYS_PD)
+    #define FLEXT_STPF_0(NAME) setup_##NAME
+    #define FLEXT_STPF_1(NAME) setup_##NAME
+#elif FLEXT_SYS == FLEXT_SYS_PD || FLEXT_SYS == FLEXT_SYS_MAX
 	#define FLEXT_STPF_0(NAME) NAME##_setup
 	#define FLEXT_STPF_1(NAME) NAME##_tilde_setup
 #else


### PR DESCRIPTION
This change allows the formation of object names containing arbitrary characters.

For example an object may be called "foo.bar":

 FLEXT_NEW("foo.bar", foo0x2ebar);
