### PR TITLE
64bit mod

### DIFF
--- a/source/flclass.h
+++ b/source/flclass.h
@@ -1117,8 +1117,12 @@ private:
 
 	static void cb_assist(flext_hdr *c,void *b,long msg,long arg,char *s);
     static void cb_click (flext_hdr *c, Point pt, short mods);
-
+#if MSP64
+    static void cb_dsp64(flext_hdr *x, t_object *dsp64, short *count, double samplerate, long maxvectorsize, long flags);
+#else
 	static void cb_dsp(flext_hdr *c,t_signal **s,short *count);
+#endif
+    
 #elif FLEXT_SYS == FLEXT_SYS_PD
 	static void cb_click(flext_hdr *z,t_floatarg xpos,t_floatarg ypos,t_floatarg shift,t_floatarg ctrl,t_floatarg alt);
 

--- a/source/fldsp.h
+++ b/source/fldsp.h
@@ -54,7 +54,14 @@ public:
 	int Blocksize() const { return blksz; }
     
 	//! returns array of input vectors (CntInSig() vectors)
-    t_sample *const *InSig() const { return vecs; }
+    t_sample *const *InSig() const {
+#if MSP64
+        return inVec;
+#else
+        
+        return vecs;
+#endif
+    }
 
 	//! returns input vector
     t_sample *InSig(int i) const { return InSig()[i]; }
@@ -63,7 +70,10 @@ public:
     // \todo cache that returned pointer
     t_sample *const *OutSig() const 
     { 
-        int i = CntInSig(); 
+        int i = CntInSig();
+#if MSP64
+        return outVec;
+#else
         // in PD we have at least one actual dsp in vector
 #if FLEXT_SYS == FLEXT_SYS_PD
         return vecs+(i?i:1); 
@@ -71,6 +81,7 @@ public:
         return vecs+i; 
 #else
 #error
+#endif
 #endif
     }
 
@@ -95,11 +106,13 @@ public:
         \return true (default)... use DSP, false, don't use DSP
     */
 	virtual bool CbDsp();
+    virtual bool CbDsp64();
 
 	/*! \brief Called with every signal vector - here you do the dsp calculation
         flext_dsp::CbSignal fills all output vectors with silence
     */
-	virtual void CbSignal();
+	virtual void CbSignal();    
+    virtual void CbSignal64();
 
 
     /*! \brief Deprecated method for CbSignal
@@ -163,7 +176,14 @@ private:
 	// not static, could be different in different patchers..
 	float srate; 
 	int blksz;
-	t_signalvec *vecs;
+	
+    
+#if MSP64
+    t_signalvec * inVec;
+    t_signalvec * outVec;
+#else
+    t_signalvec *vecs;
+#endif
 
 	// setup function
 	static void Setup(t_classid c);
@@ -175,10 +195,18 @@ private:
 
 	static inline flext_dsp *thisObject(flext_hdr *c) { return FLEXT_CAST<flext_dsp *>(c->data); } 
 
-	void SetupDsp(t_signal **sp);
+	
+    
 
 	// dsp stuff
-	static t_int *dspmeth(t_int *w); 
+	
+#if MSP64
+    static void dspmeth64(flext_hdr *x, t_object *dsp64, double **ins, long numins, double **outs, long numouts, long sampleframes, long flags, void *userparam);
+    void SetupDsp64(flext_hdr *x, t_object *dsp64, short *count, double samplerate, long maxvectorsize, long flags);
+#else
+    void SetupDsp(t_signal **sp);
+    static t_int *dspmeth(t_int *w);
+#endif
 };
 
 #include "flpopns.h"

--- a/source/flext.cpp
+++ b/source/flext.cpp
@@ -159,7 +159,11 @@ FLEXT_TEMPIMPL(void FLEXT_CLASSDEF(flext_base))::AddMessageMethods(t_class *c,bo
     
     if(dsp) {
 #if FLEXT_SYS == FLEXT_SYS_MAX
+#if MSP64
+        add_dsp64(c,cb_dsp64);
+#else
         add_dsp(c,cb_dsp);
+#endif
         dsp_initclass();
 #elif FLEXT_SYS == FLEXT_SYS_PD
         if(dspin)
@@ -246,6 +250,33 @@ FLEXT_TEMPIMPL(void FLEXT_CLASSDEF(flext_base))::cb_assist(flext_hdr *c,void * /
 }
 #endif
 
+
+#if MSP64
+FLEXT_TEMPIMPL(void FLEXT_CLASSDEF(flext_base))::cb_dsp64(flext_hdr *c, t_object *dsp64, short *count, double samplerate, long maxvectorsize, long flags)
+{
+    Locker lock(c);
+    flext_base *bobj = thisObject(c);
+	
+#if FLEXT_SYS == FLEXT_SYS_MAX
+	// we must extra-check here if it is really a DSP object
+	// obviously, for objects that are part of a library, one dsp_initclass enables DSP for all
+	if(!bobj->IsDSP()) return;
+#endif
+    
+	flext_dsp *obj;
+#ifdef FLEXT_DEBUG
+    obj = dynamic_cast<flext_dsp *>(bobj);
+#else
+    obj = static_cast<flext_dsp *>(bobj);
+#endif
+    
+    FLEXT_ASSERT(obj);
+	obj->SetupDsp64(c,dsp64,count,samplerate,maxvectorsize,flags);
+    
+}
+
+#else
+
 #if FLEXT_SYS == FLEXT_SYS_MAX
 FLEXT_TEMPIMPL(void FLEXT_CLASSDEF(flext_base))::cb_dsp(flext_hdr *c,t_signal **sp,short *count)
 #else
@@ -271,6 +302,11 @@ FLEXT_TEMPIMPL(void FLEXT_CLASSDEF(flext_base))::cb_dsp(flext_hdr *c,t_signal **
     FLEXT_ASSERT(obj);
 	obj->SetupDsp(sp);
 }
+#endif
+
+
+
+
 
 FLEXT_TEMPIMPL(bool FLEXT_CLASSDEF(flext_base))::CbIdle() { return 0; }
 

--- a/source/flinternal.h
+++ b/source/flinternal.h
@@ -73,6 +73,7 @@ typedef void t_outlet;
 //#define object_new(clss) newobject(clss)
 #define object_free(obj) freeobject((object *)(obj))
 
+#define add_dsp64(clss,meth) addmess((method)meth,const_cast<char *>("dsp64"),A_CANT,A_NOTHING)
 #define add_dsp(clss,meth) addmess((method)meth,const_cast<char *>("dsp"),A_CANT,A_NOTHING)
 #define add_bang(clss,meth) addbang((method)meth)
 #define add_float(clss,meth) addfloat((method)meth)
@@ -102,8 +103,12 @@ typedef void t_outlet;
 #define outlet_flint(o,v) outlet_int(o,(int)(v))
 #define outlet_symbol(o,s) outlet_anything(o,s,0,NULL)
 
-typedef t_perfroutine t_dspmethod;
 
+#if MSP64
+typedef t_perfroutine64 t_dspmethod;
+#else
+typedef t_perfroutine t_dspmethod;
+#endif
 #define CRITON() short state = lockout_set(1)
 #define CRITOFF() lockout_set(state) 
 

--- a/source/flprefix.h
+++ b/source/flprefix.h
@@ -349,6 +349,13 @@ WARRANTIES, see the file, "license.txt," in this distribution.
 
 #if FLEXT_SYS == FLEXT_SYS_MAX
 //  #pragma message("Compiling for Max/MSP")
+#ifndef MSP64
+#if defined __LP64__
+#define MSP64 1
+#else
+#define MSP64 0
+#endif
+#endif
 #elif FLEXT_SYS == FLEXT_SYS_PD
 //  #pragma message("Compiling for PD")
 #endif


### PR DESCRIPTION
Hi there,

I've recently needed to add 64 bit max ability in flext,
here is an implementation proposition,
I've done it fast and with specific purpose in mind, but it could be a starting point for a cleaner one

remarks : 
I kept a different callback function for 64bit (CbSignal64 )  to keep things cleaner as t_sample seamlessly become a double,  you may want handle that differently.

I kept the same Macro than Max for 64 bit ability : MSP64 ->defining it allows to switch 64bit in MaxAPI and Flext

Flextfuly yours

Martin
