### PR TITLE
Inline operator osx fix

### DIFF
--- a/flext.xcodeproj/project.pbxproj
+++ b/flext.xcodeproj/project.pbxproj
@@ -1205,30 +1205,38 @@
 		E9A5BCA20A3381C400AD9F03 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=2",
 				);
 				HEADER_SEARCH_PATHS = "$(PD)/src";
 				PRODUCT_NAME = "$(inherited)-pd_sd";
+				VALID_ARCHS = x86_64;
 			};
 			name = Development;
 		};
 		E9A5BCA30A3381C400AD9F03 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=2",
 				);
 				HEADER_SEARCH_PATHS = "$(PD)/src";
 				PRODUCT_NAME = "$(inherited)-pd_s";
+				VALID_ARCHS = x86_64;
 			};
 			name = Deployment;
 		};
 		E9A5BCA60A3381C400AD9F03 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=2",
@@ -1242,6 +1250,8 @@
 		E9A5BCA70A3381C400AD9F03 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=2",
@@ -1255,6 +1265,8 @@
 		E9A5BCAA0A3381C400AD9F03 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -1274,6 +1286,8 @@
 		E9A5BCAB0A3381C400AD9F03 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -1293,6 +1307,8 @@
 		E9A5BCAE0A3381C400AD9F03 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=1",
@@ -1309,6 +1325,8 @@
 		E9A5BCAF0A3381C400AD9F03 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=1",
@@ -1324,6 +1342,8 @@
 		E9A5BCB20A3381C400AD9F03 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=1",
@@ -1340,6 +1360,8 @@
 		E9A5BCB30A3381C400AD9F03 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"FLEXT_SYS=1",
@@ -1356,6 +1378,8 @@
 		E9A5BCB60A3381C400AD9F03 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -1378,6 +1402,8 @@
 		E9A5BCB70A3381C400AD9F03 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_CXX_LIBRARY = "compiler-default";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -1410,8 +1436,9 @@
 					FLEXT_USE_SIMD,
 					FLEXT_USE_CMEM,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
+				VALID_ARCHS = x86_64;
 				WARNING_CFLAGS = (
 					"-Wmost",
 					"-Wno-four-char-constants",
@@ -1431,8 +1458,9 @@
 					FLEXT_USE_SIMD,
 					FLEXT_USE_CMEM,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
+				VALID_ARCHS = x86_64;
 				WARNING_CFLAGS = (
 					"-Wmost",
 					"-Wno-four-char-constants",

--- a/source/flsupport.cpp
+++ b/source/flsupport.cpp
@@ -256,6 +256,31 @@ FLEXT_TEMPIMPL(void FLEXT_CLASSDEF(flext_root))::FreeAligned(void *blk)
 
 // ------------------------------------------
 
+#if defined(FLEXT_USE_CMEM)
+// define global new/delete operators
+void *operator new(size_t bytes) NEWTHROW
+{
+  return flext_root::operator new(bytes);
+}
+void operator delete(void *blk) DELTHROW
+{
+  flext_root::operator delete(blk);
+}
+
+#ifndef __MRC__ // doesn't allow new[] overloading?!
+void *operator new[](size_t bytes) NEWTHROW
+{
+  return flext_root::operator new[](bytes);
+}
+void operator delete[](void *blk) DELTHROW
+{
+  flext_root::operator delete[](blk);
+}
+#endif
+
+#endif // FLEXT_USE_CMEM
+// ------------------------------------------
+
 /*! \todo there is probably also a shortcut for Max and jMax
     \todo size checking
 */

--- a/source/flsupport.h
+++ b/source/flsupport.h
@@ -127,11 +127,11 @@ public:
 #endif
 
 // define global new/delete operators
-inline void *operator new(size_t bytes) NEWTHROW { return flext_root::operator new(bytes); }
-inline void operator delete(void *blk) DELTHROW { flext_root::operator delete(blk); }
+void *operator new(size_t bytes) NEWTHROW;
+void operator delete(void *blk) DELTHROW;
 #ifndef __MRC__ // doesn't allow new[] overloading?!
-inline void *operator new[](size_t bytes) NEWTHROW { return flext_root::operator new[](bytes); }
-inline void operator delete[](void *blk) DELTHROW { flext_root::operator delete[](blk); }
+void *operator new[](size_t bytes) NEWTHROW;
+void operator delete[](void *blk) DELTHROW;
 #endif
 
 #endif // FLEXT_USE_CMEM


### PR DESCRIPTION
I was experiencing crashes on OSX with any PD external built with flext.

After a lot of digging, moving the global new and delete operators to the cpp file (non-inline) solved it for me.

I haven't tried building for max, but I can't imagine this will cause trouble in any way.