### PR TITLE
Fix indentation

### DIFF
--- a/buildsys/mac/gnumake-gcc-flext.inc
+++ b/buildsys/mac/gnumake-gcc-flext.inc
@@ -21,9 +21,9 @@ ifdef DEBUG
 else
 ifdef PROFILE
 else
-	ifndef STRIP
-		STRIP=strip
-	endif
+ifndef STRIP
+	STRIP=strip
+endif
 	$(STRIP) -x $@ || true
 endif
 endif


### PR DESCRIPTION
I've been getting this error when compiling flext on Github Actions using `macos-latest`:

```
ifndef STRIP
make[1]: ifndef: No such file or directory
```

I'm not sure whether this is the right solution, but for me it seems to work: the error is gone and flext finishes its compilation successfully.

See also df78b1a64eb9058775b200bd4d7d555e1989ee60.