### PR TITLE
Change win-pd-gcc OUTPATH

### DIFF
--- a/buildsys/win/pd/config-gcc.def
+++ b/buildsys/win/pd/config-gcc.def
@@ -17,7 +17,7 @@ FLEXTPREFIX=/usr/local
 ###############################################################
 
 # where should the external be built?
-OUTPATH=pd-darwin
+OUTPATH=pd-gcc
 
 # where should the external be installed?
 INSTPATH=$(PDPATH)/extra


### PR DESCRIPTION
I'm not sure what's the intended name, but I think `pd-darwin` isn't it.