### PR TITLE
autotools: install flfeatures.h

### DIFF
--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -41,6 +41,7 @@ nobase_pkginclude_HEADERS = \
 	flbase.h \
 	flclass.h \
 	flext.h \
+	flfeatures.h \
 	flsupport.h \
 	flmap.h \
 	fldsp.h \


### PR DESCRIPTION
seems like the autotools bulidsystem does not install the `flfeatures.h` file.