### PR TITLE
Debian patches

### DIFF
--- a/pd-flext.pc.in
+++ b/pd-flext.pc.in
@@ -6,8 +6,9 @@ includedir=@includedir@/flext
 Name: pd-flext
 Description: C++ glue layer for Pure Data and Max
 Version: @VERSION@
-Cflags: -I${includedir} -DPD -DFLEXT_SYS=2 -DFLEXT_SHARED @FLEXT_EXT_CFLAGS@
-Libs: -L${libdir} -lflext-pd
+Requires: pd
+Cflags: -I${includedir} -DFLEXT_SYS=2 -DFLEXT_SHARED @FLEXT_EXT_CFLAGS@ -pthread
+Libs: -L${libdir} -lflext-pd -pthread
 
 ## sections below ought to be factored out into standalone .pc files
 #Name: pd-flext-static

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -9,6 +9,10 @@
 # shared libraries
 lib_LTLIBRARIES = libflext-@SYSTEM@_s.la libflext-@SYSTEM@_sd.la libflext-@SYSTEM@_t.la libflext-@SYSTEM@_td.la libflext-@SYSTEM@.la libflext-@SYSTEM@_d.la 
 
+# x:y:z -> .so.(x-z).z.y
+# .so.A.B.C -> (A+B):C:B
+VERSION_INFO = -version-info 6:2:6
+
 SRCS_FLEXT = \
 	flbase.cpp \
 	flext.cpp \
@@ -104,8 +108,8 @@ libflext_@SYSTEM@_td_la_CXXFLAGS = @DBG_FLAGS@ -static $(patsubst %,-I%,@INCLUDE
 libflext_@SYSTEM@_la_CXXFLAGS    = @OPT_FLAGS@ $(patsubst %,-I%,@INCLUDEDIRS@) -DFLEXT_SHARED -DFLEXT_EXPORTS
 libflext_@SYSTEM@_d_la_CXXFLAGS  = @DBG_FLAGS@ $(patsubst %,-I%,@INCLUDEDIRS@) -DFLEXT_SHARED -DFLEXT_EXPORTS
 
-libflext_@SYSTEM@_la_LDFLAGS  = @LD_FLAGS@ $(patsubst %,-L%,@LIBDIRS@) $(patsubst %,-l%,@libs@ $(LIB_SNDOBJ) $(LIB_STK)) $(patsubst %,-framework %,@FRAMEWORKS@)
-libflext_@SYSTEM@_d_la_LDFLAGS  = @LD_FLAGS@ $(patsubst %,-L%,@LIBDIRS@) $(patsubst %,-l%,@libs@ $(LIB_SNDOBJ) $(LIB_STK)) $(patsubst %,-framework %,@FRAMEWORKS@) 
+libflext_@SYSTEM@_la_LDFLAGS  = @LD_FLAGS@ $(patsubst %,-L%,@LIBDIRS@) $(patsubst %,-l%,@libs@ $(LIB_SNDOBJ) $(LIB_STK)) $(patsubst %,-framework %,@FRAMEWORKS@) $(VERSION_INFO)
+libflext_@SYSTEM@_d_la_LDFLAGS  = @LD_FLAGS@ $(patsubst %,-L%,@LIBDIRS@) $(patsubst %,-l%,@libs@ $(LIB_SNDOBJ) $(LIB_STK)) $(patsubst %,-framework %,@FRAMEWORKS@)  $(VERSION_INFO)
 
 #libflext_@SYSTEM@_la_LIBADD = @libs@ 
 #libflext_@SYSTEM@_d_la_LIBADD = @libs@ 

--- a/source/lockfree/cas.hpp
+++ b/source/lockfree/cas.hpp
@@ -54,7 +54,7 @@ namespace lockfree
     template <class C, class D>
     inline bool CAS(volatile C * addr,D old,D nw)
     {
-#if defined(__GNUC__) && ( (__GNUC__ > 4) || ((__GNUC__ >= 4) && (__GNUC_MINOR__ >= 1)) )
+#if defined(__GNUC__) && ( (__GNUC__ > 4) || ((__GNUC__ >= 4) && (__GNUC_MINOR__ >= 1)) ) && (!defined USE_BLOCKING_CAS)
         return __sync_bool_compare_and_swap(addr, old, nw);
 #elif defined(_MSC_VER)
         assert((size_t(addr)&3) == 0);  // a runtime check only for debug mode is somehow insufficient....
@@ -69,7 +69,7 @@ namespace lockfree
             return OSAtomicCompareAndSwap64(old,nw,addr);
         else
             assert(false);
-#elif defined(AO_HAVE_compare_and_swap_full)
+#elif defined(AO_HAVE_compare_and_swap_full) && (!defined USE_BLOCKING_CAS)
         return AO_compare_and_swap_full(reinterpret_cast<volatile AO_t*>(addr),
             reinterpret_cast<AO_t>(old),
             reinterpret_cast<AO_t>(nw));
@@ -105,7 +105,7 @@ namespace lockfree
     template <class C, class D, class E>
     inline bool CAS2(C * addr,D old1,E old2,D new1,E new2)
     {
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ( (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 2) ) ) && (defined(__i686__) || defined(__pentiumpro__) || defined(__nocona__) || defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8))
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ( (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 2) ) ) && (defined(__i686__) || defined(__pentiumpro__) || defined(__nocona__) || defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8)) && (!defined USE_BLOCKING_CAS2)
         struct packed_c
         {
             D d;
@@ -129,7 +129,7 @@ namespace lockfree
         return __sync_bool_compare_and_swap_8(reinterpret_cast<volatile long long*>(addr),
             old.l,
             nw.l);
-#elif defined(__GNUC__) && ((__GNUC__ >  4) || ( (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 2) ) ) && (defined(__x86_64__) || defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16))
+#elif defined(__GNUC__) && ((__GNUC__ >  4) || ( (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 2) ) ) && (defined(__x86_64__) || defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16)) && (!defined USE_BLOCKING_CAS2)
         struct packed_c
         {
             D d;
@@ -174,7 +174,7 @@ namespace lockfree
             setz [ok]
         }
         return ok;
-#elif defined(__GNUC__) && (defined(__i386__) || defined(__i686__) || defined(__x86_64__))
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__i686__) || defined(__x86_64__)) && (!defined USE_BLOCKING_CAS2)
         char result;
         if(sizeof(D) == 4 && sizeof(E) == 4) {
             #ifndef __PIC__
@@ -198,7 +198,7 @@ namespace lockfree
         else
             assert(false);
         return result != 0;
-#elif defined(AO_HAVE_double_compare_and_swap_full)
+#elif defined(AO_HAVE_double_compare_and_swap_full) && (!defined USE_BLOCKING_CAS2)
         if (sizeof(D) != sizeof(AO_t) || sizeof(E) != sizeof(AO_t)) {
             assert(false);
             return false;


### PR DESCRIPTION
just forwarding patches from that are used in the Debian packages for flext

- Closes: #50 
   As discussed in https://github.com/grrrr/flext/issues/50#issuecomment-1323240907
- add API-version to the dynamic libraries
  - this requires the API-version to be specified manually in `source/Makefile.am`. the API-version is currently set to `6:2:6` (evaluating to `libflext-pd.so.0.6.2`), so its initial value is based on the release version of flext. In general it is a bad idea to lock the two too tightly (as in: you probably shouldn't parse the package version defined in `configure.ac` to calculate the API version; see [here](https://www.gnu.org/software/libtool/manual/libtool.html#Updating-version-info) and [there](https://autotools.info/libtool/version.html))
- pkg-config: depend on `pd` package, and add `-pthread` to the reported flags
  - this requires that Pd is installed in a way to make the `pd` pkg-config package available. I guess it is safe to assume that on systems where flext is installed with a system-usable `pd-flext.pc`, there will also be a `pd.pc` available.
