### PR TITLE
Pd64 compatibility (double precision flext)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@ dnl '
 FLEXT_EXT_CFLAGS=""
 
 AC_CANONICAL_HOST
+AC_LANG(C++)
+
 AS_CASE([$host],
  [*mingw*|*cygwin*], [win=1],
  [win=""])
@@ -54,71 +56,95 @@ AC_ARG_WITH(pdbindir,
   AS_IF([test -n "${win}"], AC_MSG_ERROR(path to pd bin dir required))
 ])
 
+# RTE
+CPPFLAGS_tmp="${CPPFLAGS}"
+CPPFLAGS="${CPPFLAGS} -I${sdkdir}"
 AS_CASE([$SYSTEM],
  [max], [
     AC_DEFINE(FLEXT_SYS,1)
 # check for MaxAPI.h in pd folder
-    AC_CHECK_FILE([$sdkdir/max-includes/MaxAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAPI.h]))
-    AC_CHECK_FILE([$sdkdir/max-includes/MaxAudioAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAudioAPI.h]))
+    AC_CHECK_HEADER([max-includes/MaxAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAPI.h]))
+    AC_CHECK_HEADER([max-includes/MaxAudioAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAudioAPI.h]))
     INCLUDEDIRS="$INCLUDEDIRS $sdkdir/max-includes $sdkdir/msp-includes"
- ], [pd], [
+    pddll=""
+    ],
+ [pd], [
     AC_DEFINE(FLEXT_SYS,2)
 # check for g_canvas.h in pd folder
-    AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
+    AC_CHECK_HEADER([g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]),[
+      #include "m_pd.h"
+    ])
     INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
+    pddll=pd
+    pdfun=class_new
+    ],
+ [pd64], [
+    AC_DEFINE(FLEXT_SYS,2)
+# check for g_canvas.h in pd folder
+    AC_CHECK_HEADER([g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]),[
+      #include "m_pd.h"
+    ])
+    INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
+    pddll=pd64
+    pdfun=class_new64
 
-    AS_IF([test -n "${win}"],
-        AC_CHECK_FILE(["${pdbindir}/pd.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd.dll]))
-        libs="$libs pd"
-        AC_DEFINE([NT])
-    )
- ], [pd64], [
-    AC_DEFINE(FLEXT_SYS,2)
-# check for g_canvas.h in pd folder
-    AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
-    INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
     AC_DEFINE([PD_FLOATSIZE], 64, [size of Pd floats (in bits)])
-    FLEXT_EXT_CFLAGS="$FLEXT_EXT_CFLAGS -DPD_FLOATSIZE=64"
-
-    AS_IF([test -n "${win}"],
-      AC_CHECK_FILE(["${pdbindir}/pd64.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd64.dll]))
-      libs="$libs pd64"
-      AC_DEFINE([NT])
-    )
- ],[
+    FLEXT_EXT_CFLAGS="$FLEXT_EXT_CFLAGS -DPD_FLOATSIZE=64"],
+ [
     AC_MSG_ERROR([system must be pd or max])
 ])
 
+LIBS_tmp="${LIBS}"
+AS_IF([test -n "${pddll}" && test -n "${win}"],
+  LIBS="${LIBS} -L${pdbindir}"
+  AC_CHECK_LIB([:${pddll}.dll], [$pdfun], [], [AC_MSG_ERROR([Cannot find/use $pdbindir/$pddll.dll])])
+  libs="$libs pddll"
+  AC_DEFINE([NT])
+)
+CPPFLAGS="${CPPFLAGS_tmp}"
+LIBS="${LIBS_tmp}"
+
+
+## atomic_ops
+CPPFLAGS_tmp="${CPPFLAGS}"
 AC_ARG_WITH(atomic_ops,
   AS_HELP_STRING([--with-atomic_ops],[path to atomic_ops library (needed for gcc version < 4.1 on non-i386 cpus)]),
   [
-    AC_CHECK_FILE([$withval/atomic_ops.h],,AC_MSG_ERROR([Cannot find $withval/atomic_ops.h]))
+    CPPFLAGS="${CPPFLAGS} -I${withval}"
+    AC_CHECK_HEADER([atomic_ops.h],,AC_MSG_ERROR([Cannot find $withval/atomic_ops.h]))
     INCLUDEDIRS="$INCLUDEDIRS $withval"
     AC_DEFINE(USE_ATOMIC_OPS)
   ]
 )
+CPPFLAGS="${CPPFLAGS_tmp}"
 
+## STK
+CPPFLAGS_tmp="${CPPFLAGS}"
 AC_ARG_WITH(stkdir,
   AS_HELP_STRING([--with-stkdir],[path to STK headers]),
   [
-    AC_CHECK_FILE([$withval/Stk.h],,AC_MSG_ERROR([Cannot find $withval/Stk.h]))
+    CPPFLAGS="${CPPFLAGS} -I${withval}"
+    AC_CHECK_HEADER([Stk.h],,AC_MSG_ERROR([Cannot find $withval/Stk.h]))
     stkdir=$withval
     INCLUDEDIRS="$INCLUDEDIRS $withval"
   ]
 )
-
 AM_CONDITIONAL([STK],[test "$stkdir"])
+CPPFLAGS="${CPPFLAGS_tmp}"
 
+## SndObj
+CPPFLAGS_tmp="${CPPFLAGS}"
 AC_ARG_WITH(sndobjdir,
   AS_HELP_STRING([--with-sndobjdir],[path to SndObj headers]),
   [
-    AC_CHECK_FILE([$withval/SndObj.h],,AC_MSG_ERROR([Cannot find $withval/SndObj.h]))
+    CPPFLAGS="${CPPFLAGS} -I${withval}"
+    AC_CHECK_HEADER([SndObj.h],,AC_MSG_ERROR([Cannot find $withval/SndObj.h]))
     sndobjdir=$withval
     INCLUDEDIRS="$INCLUDEDIRS $withval"
   ]
 )
-
 AM_CONDITIONAL([SNDOBJ],[test "$sndobjdir"])
+CPPFLAGS="${CPPFLAGS_tmp}"
 
 # if CFLAGS aren't set by the user, set them to an empty string
 # otherwise AC_PROG_CC sets them to "-O2 -g"
@@ -135,8 +161,6 @@ AC_PROG_CXX
 LT_INIT
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-
-AC_LANG(C++)
 
 # Checks for libraries.
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,14 @@ AC_INIT([flext],[0.6.2],[gr@grrrr.org])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_MACRO_DIRS([m4])
 
+AU_DEFUN([AC_LIBTOOL_WIN32_DLL],
+[AC_REQUIRE([AC_CANONICAL_HOST])dnl
+_LT_SET_OPTION([LT_INIT], [win32-dll])
+AC_DIAGNOSE([obsolete],
+[$0: Remove this warning and the call to _LT_SET_OPTION when you
+put the `win32-dll' option into LT_INIT's first parameter.])
+])
+
 # TODO: this should definitely be changed to work with any version of CYGWIN_NT or MINGW32_NT
 if ( test $(uname -s) == CYGWIN_NT-5.0 ) || ( test $(uname -s) == CYGWIN_NT-5.1 ) || ( test $(uname -s) == MINGW32_NT-5.1 ); then
 	set win = 1
@@ -108,14 +116,6 @@ AM_CONDITIONAL([SNDOBJ],[test "$sndobjdir"])
 # otherwise AC_PROG_CC sets them to "-O2 -g" 
 test ".$CFLAGS" = "." && CFLAGS=" "
 test ".$CXXFLAGS" = "." && CXXFLAGS=" "
-
-AU_DEFUN([AC_LIBTOOL_WIN32_DLL],
-[AC_REQUIRE([AC_CANONICAL_HOST])dnl
-_LT_SET_OPTION([LT_INIT], [win32-dll])
-AC_DIAGNOSE([obsolete],
-[$0: Remove this warning and the call to _LT_SET_OPTION when you
-put the `win32-dll' option into LT_INIT's first parameter.])
-])
 
 
 AC_ENABLE_STATIC([])

--- a/configure.ac
+++ b/configure.ac
@@ -41,45 +41,35 @@ AC_ARG_WITH(externalsdir,
   [EXTDIR="${withval}"])
 
 AC_ARG_WITH(pdbindir,
-	AS_HELP_STRING([--with-pdbindir],[path to pd bin dir]),
-	[
-		if test $win; then
-# LATER: shouldn't we use AC_CHECK_LIB([pd]) ?
-		 AC_CHECK_FILE([$withval/pd.dll],,AC_MSG_ERROR([Cannot find $withval/pd.dll]))
-		fi
-		LIBDIRS="$LIBDIRS $withval"
-                AS_IF([test -z "${EXTDIR}"], EXTDIR="${withval}/../extra")
-	],
-	[
-		if test $win; then
-			AC_MSG_ERROR(path to pd bin dir required)
-		fi
-	]
-)
+  AS_HELP_STRING([--with-pdbindir],[path to pd bin dir]), [
+  pdbindir="${withval}"
+  LIBDIRS="$LIBDIRS $withval"
+  AS_IF([test -z "${EXTDIR}"], EXTDIR="${withval}/../extra")
+],[
+  AS_IF([test -n "${win}"], AC_MSG_ERROR(path to pd bin dir required))
+])
 
-if test $SYSTEM == max; then
+AS_CASE([$SYSTEM],
+ [max], [
 	AC_DEFINE(FLEXT_SYS,1)
 # check for MaxAPI.h in pd folder
 	AC_CHECK_FILE([$sdkdir/max-includes/MaxAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAPI.h]))
 	AC_CHECK_FILE([$sdkdir/max-includes/MaxAudioAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAudioAPI.h]))
 	INCLUDEDIRS="$INCLUDEDIRS $sdkdir/max-includes $sdkdir/msp-includes"
-
-elif test $SYSTEM == pd; then
-#	if test $win; then
-#	fi
-
+  ], [pd], [
 	AC_DEFINE(FLEXT_SYS,2)
 # check for g_canvas.h in pd folder
 	AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
 	INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
 
-	if test $win; then
-		libs="$libs pd"
-		AC_DEFINE(NT)
-	fi
-else
+        AS_IF([test -n "${win}"],
+            AC_CHECK_FILE(["${pdbindir}/pd.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd.dll]))
+            libs="$libs pd"
+            AC_DEFINE([NT])
+        )
+   ],[
 	AC_MSG_ERROR([system must be pd or max])
-fi
+   ])
 
 AC_ARG_WITH(atomic_ops,
 	AS_HELP_STRING([--with-atomic_ops],[path to atomic_ops library (needed for gcc version < 4.1 on non-i386 cpus)]),

--- a/configure.ac
+++ b/configure.ac
@@ -18,10 +18,10 @@ AC_DIAGNOSE([obsolete],
 put the `win32-dll' option into LT_INIT's first parameter.])
 ])
 
-# TODO: this should definitely be changed to work with any version of CYGWIN_NT or MINGW32_NT
-if ( test $(uname -s) == CYGWIN_NT-5.0 ) || ( test $(uname -s) == CYGWIN_NT-5.1 ) || ( test $(uname -s) == MINGW32_NT-5.1 ); then
-	set win = 1
-fi
+
+AS_CASE([$host],
+ [*mingw*|*cygwin*], [win=1],
+ [win=""])
 
 # configure options
 AC_ARG_ENABLE(system,
@@ -143,19 +143,21 @@ AC_STRUCT_TM
 # Checks for library functions.
 
 # system specific
-if test $(uname -s) == Linux; then
+AS_CASE([$host],
+ [*linux*|*kfreebsd*gnu*],[
 	C_FLAGS="$C_FLAGS -fPIC"
 	LD_FLAGS="$LD_FLAGS -shared"
 	EXTENSION=pd_linux
-elif test $(uname -s) == Darwin; then
+ ], [*darwin*],[
 	FRAMEWORKS="$FRAMEWORKS ApplicationServices Accelerate"
 	LD_FLAGS="$LD_FLAGS -flat_namespace -undefined dynamic_lookup"
 	EXTENSION=pd_darwin
-elif test $win; then
+ ], [*mingw*|*cygwin*], [
 	C_FLAGS="$C_FLAGS -mms-bitfields -mno-cygwin"
 	LD_FLAGS="$LD_FLAGS -mno-cygwin"
 	EXTENSION=dll
-fi
+])
+
 
 AS_IF([test -z "${EXTDIR}"], EXTDIR="/usr/local/lib/pd-externals")
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,8 @@ put the `win32-dll' option into LT_INIT's first parameter.])
 ])
 
 
+FLEXT_EXT_CFLAGS=""
+
 AS_CASE([$host],
  [*mingw*|*cygwin*], [win=1],
  [win=""])
@@ -66,6 +68,19 @@ AS_CASE([$SYSTEM],
             AC_CHECK_FILE(["${pdbindir}/pd.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd.dll]))
             libs="$libs pd"
             AC_DEFINE([NT])
+        )
+  ], [pd64], [
+	AC_DEFINE(FLEXT_SYS,2)
+# check for g_canvas.h in pd folder
+	AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
+	INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
+        AC_DEFINE([PD_FLOATSIZE], 64, [size of Pd floats (in bits)])
+	FLEXT_EXT_CFLAGS="$FLEXT_EXT_CFLAGS -DPD_FLOATSIZE=64"
+
+        AS_IF([test -n "${win}"],
+          AC_CHECK_FILE(["${pdbindir}/pd64.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd64.dll]))
+          libs="$libs pd64"
+          AC_DEFINE([NT])
         )
    ],[
 	AC_MSG_ERROR([system must be pd or max])
@@ -167,7 +182,6 @@ AS_IF([test -z "${EXTDIR}"], EXTDIR="/usr/local/lib/pd-externals")
 
 OPT_FLAGS="$C_FLAGS -O3"
 DBG_FLAGS="$C_FLAGS -DFLEXT_DEBUG -g"
-FLEXT_EXT_CFLAGS=""
 
 AC_ARG_ENABLE(optimize, 
 	AS_HELP_STRING([--enable-optimize],[enables optimized architecture specific builds for pentium4, pentium3, G4, G5, etc.]),

--- a/configure.ac
+++ b/configure.ac
@@ -15,27 +15,30 @@ AU_DEFUN([AC_LIBTOOL_WIN32_DLL],
 _LT_SET_OPTION([LT_INIT], [win32-dll])
 AC_DIAGNOSE([obsolete],
 [$0: Remove this warning and the call to _LT_SET_OPTION when you
-put the `win32-dll' option into LT_INIT's first parameter.])
+put the 'win32-dll' option into LT_INIT's first parameter.])
 ])
+
+dnl '
 
 
 FLEXT_EXT_CFLAGS=""
 
+AC_CANONICAL_HOST
 AS_CASE([$host],
  [*mingw*|*cygwin*], [win=1],
  [win=""])
 
 # configure options
 AC_ARG_ENABLE(system,
-	AS_HELP_STRING([--enable-system],[realtime system [default=pd]]),
+    AS_HELP_STRING([--enable-system],[realtime system [default=pd]]),
     [SYSTEM=$enableval],
     [SYSTEM=pd]
 )
 
 AC_ARG_WITH(sdkdir,
-	AS_HELP_STRING([--with-sdkdir],[path to pd or max headers]),
-    [sdkdir=$withval],
-	AC_MSG_ERROR(path to system SDK headers required $withval)
+  AS_HELP_STRING([--with-sdkdir],[path to pd or max headers]),
+  [sdkdir=$withval],
+  AC_MSG_ERROR(path to system SDK headers required $withval)
 )
 
 AC_ARG_WITH(externalsdir,
@@ -53,72 +56,72 @@ AC_ARG_WITH(pdbindir,
 
 AS_CASE([$SYSTEM],
  [max], [
-	AC_DEFINE(FLEXT_SYS,1)
+    AC_DEFINE(FLEXT_SYS,1)
 # check for MaxAPI.h in pd folder
-	AC_CHECK_FILE([$sdkdir/max-includes/MaxAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAPI.h]))
-	AC_CHECK_FILE([$sdkdir/max-includes/MaxAudioAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAudioAPI.h]))
-	INCLUDEDIRS="$INCLUDEDIRS $sdkdir/max-includes $sdkdir/msp-includes"
-  ], [pd], [
-	AC_DEFINE(FLEXT_SYS,2)
+    AC_CHECK_FILE([$sdkdir/max-includes/MaxAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAPI.h]))
+    AC_CHECK_FILE([$sdkdir/max-includes/MaxAudioAPI.h],,AC_MSG_ERROR([Cannot find $sdkdir/max-includes/MaxAudioAPI.h]))
+    INCLUDEDIRS="$INCLUDEDIRS $sdkdir/max-includes $sdkdir/msp-includes"
+ ], [pd], [
+    AC_DEFINE(FLEXT_SYS,2)
 # check for g_canvas.h in pd folder
-	AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
-	INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
+    AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
+    INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
 
-        AS_IF([test -n "${win}"],
-            AC_CHECK_FILE(["${pdbindir}/pd.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd.dll]))
-            libs="$libs pd"
-            AC_DEFINE([NT])
-        )
-  ], [pd64], [
-	AC_DEFINE(FLEXT_SYS,2)
+    AS_IF([test -n "${win}"],
+        AC_CHECK_FILE(["${pdbindir}/pd.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd.dll]))
+        libs="$libs pd"
+        AC_DEFINE([NT])
+    )
+ ], [pd64], [
+    AC_DEFINE(FLEXT_SYS,2)
 # check for g_canvas.h in pd folder
-	AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
-	INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
-        AC_DEFINE([PD_FLOATSIZE], 64, [size of Pd floats (in bits)])
-	FLEXT_EXT_CFLAGS="$FLEXT_EXT_CFLAGS -DPD_FLOATSIZE=64"
+    AC_CHECK_FILE([$sdkdir/g_canvas.h],,AC_MSG_ERROR([Cannot find $sdkdir/g_canvas.h]))
+    INCLUDEDIRS="$INCLUDEDIRS $sdkdir"
+    AC_DEFINE([PD_FLOATSIZE], 64, [size of Pd floats (in bits)])
+    FLEXT_EXT_CFLAGS="$FLEXT_EXT_CFLAGS -DPD_FLOATSIZE=64"
 
-        AS_IF([test -n "${win}"],
-          AC_CHECK_FILE(["${pdbindir}/pd64.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd64.dll]))
-          libs="$libs pd64"
-          AC_DEFINE([NT])
-        )
-   ],[
-	AC_MSG_ERROR([system must be pd or max])
-   ])
+    AS_IF([test -n "${win}"],
+      AC_CHECK_FILE(["${pdbindir}/pd64.dll"],,AC_MSG_ERROR([Cannot find $pdbindir/pd64.dll]))
+      libs="$libs pd64"
+      AC_DEFINE([NT])
+    )
+ ],[
+    AC_MSG_ERROR([system must be pd or max])
+])
 
 AC_ARG_WITH(atomic_ops,
-	AS_HELP_STRING([--with-atomic_ops],[path to atomic_ops library (needed for gcc version < 4.1 on non-i386 cpus)]),
-	[
-	    AC_CHECK_FILE([$withval/atomic_ops.h],,AC_MSG_ERROR([Cannot find $withval/atomic_ops.h]))
-		INCLUDEDIRS="$INCLUDEDIRS $withval"
-        AC_DEFINE(USE_ATOMIC_OPS)
-	]
+  AS_HELP_STRING([--with-atomic_ops],[path to atomic_ops library (needed for gcc version < 4.1 on non-i386 cpus)]),
+  [
+    AC_CHECK_FILE([$withval/atomic_ops.h],,AC_MSG_ERROR([Cannot find $withval/atomic_ops.h]))
+    INCLUDEDIRS="$INCLUDEDIRS $withval"
+    AC_DEFINE(USE_ATOMIC_OPS)
+  ]
 )
 
 AC_ARG_WITH(stkdir,
-	AS_HELP_STRING([--with-stkdir],[path to STK headers]),
-	[
-	    AC_CHECK_FILE([$withval/Stk.h],,AC_MSG_ERROR([Cannot find $withval/Stk.h]))
-		stkdir=$withval
-		INCLUDEDIRS="$INCLUDEDIRS $withval"
-	]
+  AS_HELP_STRING([--with-stkdir],[path to STK headers]),
+  [
+    AC_CHECK_FILE([$withval/Stk.h],,AC_MSG_ERROR([Cannot find $withval/Stk.h]))
+    stkdir=$withval
+    INCLUDEDIRS="$INCLUDEDIRS $withval"
+  ]
 )
 
 AM_CONDITIONAL([STK],[test "$stkdir"])
 
 AC_ARG_WITH(sndobjdir,
-	AS_HELP_STRING([--with-sndobjdir],[path to SndObj headers]),
-	[
-		AC_CHECK_FILE([$withval/SndObj.h],,AC_MSG_ERROR([Cannot find $withval/SndObj.h]))
-		sndobjdir=$withval
-		INCLUDEDIRS="$INCLUDEDIRS $withval"
-	]
+  AS_HELP_STRING([--with-sndobjdir],[path to SndObj headers]),
+  [
+    AC_CHECK_FILE([$withval/SndObj.h],,AC_MSG_ERROR([Cannot find $withval/SndObj.h]))
+    sndobjdir=$withval
+    INCLUDEDIRS="$INCLUDEDIRS $withval"
+  ]
 )
 
 AM_CONDITIONAL([SNDOBJ],[test "$sndobjdir"])
 
 # if CFLAGS aren't set by the user, set them to an empty string
-# otherwise AC_PROG_CC sets them to "-O2 -g" 
+# otherwise AC_PROG_CC sets them to "-O2 -g"
 test ".$CFLAGS" = "." && CFLAGS=" "
 test ".$CXXFLAGS" = "." && CXXFLAGS=" "
 
@@ -150,21 +153,21 @@ AC_STRUCT_TM
 # system specific
 AS_CASE([$host],
  [*linux*|*kfreebsd*gnu*],[
-	C_FLAGS="$C_FLAGS -fPIC"
-	LD_FLAGS="$LD_FLAGS -shared"
-	EXTENSION=pd_linux
+    C_FLAGS="$C_FLAGS -fPIC"
+    LD_FLAGS="$LD_FLAGS -shared"
+    EXTENSION=pd_linux
  ], [*darwin*],[
-	FRAMEWORKS="$FRAMEWORKS ApplicationServices Accelerate"
-	LD_FLAGS="$LD_FLAGS -flat_namespace -undefined dynamic_lookup"
-	EXTENSION=pd_darwin
+    FRAMEWORKS="$FRAMEWORKS ApplicationServices Accelerate"
+    LD_FLAGS="$LD_FLAGS -flat_namespace -undefined dynamic_lookup"
+    EXTENSION=pd_darwin
  ], [*mingw*|*cygwin*], [
-	C_FLAGS="$C_FLAGS -mms-bitfields -mno-cygwin"
-	LD_FLAGS="$LD_FLAGS -mno-cygwin"
-	EXTENSION=dll
+    C_FLAGS="$C_FLAGS -mms-bitfields -mno-cygwin"
+    LD_FLAGS="$LD_FLAGS -mno-cygwin"
+    EXTENSION=dll
  ], [ # default: like linux (but require extension via the --with-extension flag)
-	C_FLAGS="$C_FLAGS -fPIC"
-	LD_FLAGS="$LD_FLAGS -shared"
-	#EXTENSION=
+    C_FLAGS="$C_FLAGS -fPIC"
+    LD_FLAGS="$LD_FLAGS -shared"
+    #EXTENSION=
 ])
 
 AC_ARG_WITH([extension],
@@ -183,34 +186,33 @@ AS_IF([test -z "${EXTDIR}"], EXTDIR="/usr/local/lib/pd-externals")
 OPT_FLAGS="$C_FLAGS -O3"
 DBG_FLAGS="$C_FLAGS -DFLEXT_DEBUG -g"
 
-AC_ARG_ENABLE(optimize, 
-	AS_HELP_STRING([--enable-optimize],[enables optimized architecture specific builds for pentium4, pentium3, G4, G5, etc.]),
-    [
-        # tune to a specific CPU
-		OPT_FLAGS="$OPT_FLAGS -mtune=$enableval"
-		case $enableval in
-			pentium | pentium2 | athlon | pentium-mmx)
-				OPT_FLAGS="$OPT_FLAGS -march=$enableval";;
-			pentium3 | pentium3m | pentium4 | pentium4m | pentium-m | prescott | nocona | athlon-xp | athlon-mp | athlon64 | opteron)
-				OPT_FLAGS="$OPT_FLAGS -march=$enableval -mfpmath=sse";
-				AC_DEFINE(FLEXT_USE_SIMD);;
-			G3)
-                # set specific architecture (like march)
-				OPT_FLAGS="$OPT_FLAGS -mcpu=$enableval";;
-			G5 | G4)
-                # set specific architecture (like march)
-				OPT_FLAGS="$OPT_FLAGS -mcpu=$enableval -faltivec";
-				AC_DEFINE(FLEXT_USE_SIMD);;
-			*)
-				;;
-		esac
-	]
+AC_ARG_ENABLE(optimize,
+  AS_HELP_STRING([--enable-optimize],[enables optimized architecture specific builds for pentium4, pentium3, G4, G5, etc.]),
+  [
+    # tune to a specific CPU
+    OPT_FLAGS="$OPT_FLAGS -mtune=$enableval"
+    AS_CASE([$enableval],
+      [pentium|pentium2|athlon|pentium-mmx],[
+        OPT_FLAGS="$OPT_FLAGS -march=$enableval"
+      ],[pentium3|pentium3m|pentium4|pentium4m|pentium-m|prescott|nocona|athlon-xp|athlon-mp|athlon64|opteron],[
+        OPT_FLAGS="$OPT_FLAGS -march=$enableval -mfpmath=sse"
+        AC_DEFINE(FLEXT_USE_SIMD)
+      ],[G3],[
+        # set specific architecture (like march)
+        OPT_FLAGS="$OPT_FLAGS -mcpu=$enableval"
+      ],[G5|G4],[
+        # set specific architecture (like march)
+        OPT_FLAGS="$OPT_FLAGS -mcpu=$enableval -faltivec"
+        AC_DEFINE(FLEXT_USE_SIMD)
+      ])
+   ]
 )
 AC_ARG_ENABLE([cmem],
-	AS_HELP_STRING([--enable-cmem],[enables C-style memory allocation (as opposed to overloading 'new' and 'delete')]),
-        AS_CASE([$enableval], [yes], [
-		AC_DEFINE(FLEXT_USE_CMEM)
-		FLEXT_EXT_CFLAGS="$FLEXT_EXT_CFLAGS -DFLEXT_USE_CMEM"]))
+  AS_HELP_STRING([--enable-cmem],[enables C-style memory allocation (as opposed to overloading 'new' and 'delete')]),
+  AS_CASE([$enableval], [yes], [
+    AC_DEFINE(FLEXT_USE_CMEM)
+    FLEXT_EXT_CFLAGS="$FLEXT_EXT_CFLAGS -DFLEXT_USE_CMEM"])
+)
 
 
 AC_SUBST(SYSTEM)
@@ -230,31 +232,31 @@ AC_SUBST(EXTENSION)
 AC_SUBST(EXTDIR)
 
 AC_CONFIG_FILES([
-			$SYSTEM-flext.pc
-			Makefile
-			source/Makefile
-			tutorial/Makefile
-			tutorial/1_simple1/Makefile
-			tutorial/1_simple2/Makefile
-			tutorial/1_simple3/Makefile
-			tutorial/2_adv1/Makefile
-			tutorial/2_adv2/Makefile
-			tutorial/2_adv3/Makefile
-			tutorial/3_attr1/Makefile
-			tutorial/3_attr2/Makefile
-			tutorial/3_attr3/Makefile
-			tutorial/4_bind1/Makefile
-			tutorial/4_buffer1/Makefile
-			tutorial/4_timer1/Makefile
-			tutorial/5_signal1/Makefile
-			tutorial/5_signal2/Makefile
-			tutorial/6_lib1/Makefile
-			tutorial/7_thread1/Makefile
-			tutorial/7_thread2/Makefile
-			tutorial/8_sndobj1/Makefile
-			tutorial/8_stk1/Makefile
-			tutorial/8_stk2/Makefile
-			tutorial/pd/Makefile
-			tutorial/maxmsp/Makefile
+  $SYSTEM-flext.pc
+  Makefile
+  source/Makefile
+  tutorial/Makefile
+  tutorial/1_simple1/Makefile
+  tutorial/1_simple2/Makefile
+  tutorial/1_simple3/Makefile
+  tutorial/2_adv1/Makefile
+  tutorial/2_adv2/Makefile
+  tutorial/2_adv3/Makefile
+  tutorial/3_attr1/Makefile
+  tutorial/3_attr2/Makefile
+  tutorial/3_attr3/Makefile
+  tutorial/4_bind1/Makefile
+  tutorial/4_buffer1/Makefile
+  tutorial/4_timer1/Makefile
+  tutorial/5_signal1/Makefile
+  tutorial/5_signal2/Makefile
+  tutorial/6_lib1/Makefile
+  tutorial/7_thread1/Makefile
+  tutorial/7_thread2/Makefile
+  tutorial/8_sndobj1/Makefile
+  tutorial/8_stk1/Makefile
+  tutorial/8_stk2/Makefile
+  tutorial/pd/Makefile
+  tutorial/maxmsp/Makefile
 ])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,10 @@ AC_ARG_WITH(sdkdir,
 	AC_MSG_ERROR(path to system SDK headers required $withval)
 )
 
+AC_ARG_WITH(externalsdir,
+  AS_HELP_STRING([--with-externalsdir],[path to install externals to]),
+  [EXTDIR="${withval}"])
+
 AC_ARG_WITH(pdbindir,
 	AS_HELP_STRING([--with-pdbindir],[path to pd bin dir]),
 	[
@@ -36,6 +40,7 @@ AC_ARG_WITH(pdbindir,
 		 AC_CHECK_FILE([$withval/pd.dll],,AC_MSG_ERROR([Cannot find $withval/pd.dll]))
 		fi
 		LIBDIRS="$LIBDIRS $withval"
+                AS_IF([test -z "${EXTDIR}"], EXTDIR="${withval}/../extra")
 	],
 	[
 		if test $win; then
@@ -152,6 +157,8 @@ elif test $win; then
 	EXTENSION=dll
 fi
 
+AS_IF([test -z "${EXTDIR}"], EXTDIR="/usr/local/lib/pd-externals")
+
 
 # set compilation flags
 
@@ -203,6 +210,7 @@ AC_SUBST(FRAMEWORKS)
 AC_SUBST(FLEXT_EXT_CFLAGS)
 
 AC_SUBST(EXTENSION)
+AC_SUBST(EXTDIR)
 
 AC_CONFIG_FILES([
 			$SYSTEM-flext.pc

--- a/configure.ac
+++ b/configure.ac
@@ -156,8 +156,19 @@ AS_CASE([$host],
 	C_FLAGS="$C_FLAGS -mms-bitfields -mno-cygwin"
 	LD_FLAGS="$LD_FLAGS -mno-cygwin"
 	EXTENSION=dll
+ ], [ # default: like linux (but require extension via the --with-extension flag)
+	C_FLAGS="$C_FLAGS -fPIC"
+	LD_FLAGS="$LD_FLAGS -shared"
+	#EXTENSION=
 ])
 
+AC_ARG_WITH([extension],
+ AS_HELP_STRING([--with-extension=dll],[use the given extension instead of the platform-specific default]),
+ AS_CASE([$withval], [yes|no|""], [], [EXTENSION=$withval]))
+
+AC_MSG_CHECKING([extension])
+AS_IF([test -z "${EXTENSION}"], AC_MSG_ERROR([Unable to autodetect extension and none given...]))
+AC_MSG_RESULT([${EXTENSION}])
 
 AS_IF([test -z "${EXTDIR}"], EXTDIR="/usr/local/lib/pd-externals")
 

--- a/configure.ac
+++ b/configure.ac
@@ -194,12 +194,17 @@ AS_CASE([$host],
     #EXTENSION=
 ])
 
+# In case of pd64, forget default extension definitions
+AS_IF([test "${SYSTEM}" == pd64], [EXTENSION=])
+# A new extension format .${os}_${arch}_${floatsize}.${sysext} is needed,
+# which (for now) must be explicitly given through the --with-extension option
+
 AC_ARG_WITH([extension],
  AS_HELP_STRING([--with-extension=dll],[use the given extension instead of the platform-specific default]),
  AS_CASE([$withval], [yes|no|""], [], [EXTENSION=$withval]))
 
 AC_MSG_CHECKING([extension])
-AS_IF([test -z "${EXTENSION}"], AC_MSG_ERROR([Unable to autodetect extension and none given...]))
+AS_IF([test -z "${EXTENSION}"], AC_MSG_ERROR([Unable to autodetect extension and none given... (pd64 system currently requires --with-extension)]))
 AC_MSG_RESULT([${EXTENSION}])
 
 AS_IF([test -z "${EXTDIR}"], EXTDIR="/usr/local/lib/pd-externals")

--- a/pd-flext.pc.in
+++ b/pd-flext.pc.in
@@ -3,19 +3,19 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@/flext
 
-Name: pd-flext
+Name: @SYSTEM@-flext
 Description: C++ glue layer for Pure Data and Max
 Version: @VERSION@
 Requires: pd
 Cflags: -I${includedir} -DFLEXT_SYS=2 -DFLEXT_SHARED @FLEXT_EXT_CFLAGS@ -pthread
-Libs: -L${libdir} -lflext-pd -pthread
+Libs: -L${libdir} -lflext-@SYSTEM@ -pthread
 
 ## sections below ought to be factored out into standalone .pc files
 #Name: pd-flext-static
 #Description: C++ glue layer for Pure Data and Max (static)
 #Version: @VERSION@
 #Cflags: -I${includedir} -DPD
-#Libs: -L${libdir} -lflext-pd_s
+#Libs: -L${libdir} -lflext-@SYSTEM@_s
 #
 #Name: pd-flext-inline
 #Description: C++ glue layer for Pure Data and Max (inline)

--- a/pd64-flext.pc.in
+++ b/pd64-flext.pc.in
@@ -1,0 +1,1 @@
+pd-flext.pc.in

--- a/tutorial/common.mk
+++ b/tutorial/common.mk
@@ -11,7 +11,7 @@ BUILT_SOURCES = main.cpp
 CXXFLAGS  = @CXXFLAGS@ \
 	@OPT_FLAGS@ \
 	$(patsubst %,-I%,@INCLUDEDIRS@) \
-	-I../../source \
+	-I@top_srcdir@/source \
     -D FLEXT_INLINE=1 \
 	$(DEFS) \
 	-DFLEXT_SHARED
@@ -31,7 +31,6 @@ SYSDIR = @SYSDIR@
 
 all-local: $(OBJECTS)
 	$(CXX) $(LDFLAGS) ./*.@OBJEXT@ $(LIBS) -o ./$(TARGET)
-	strip -x ./$(TARGET)
 
 ./%.@OBJEXT@ : %.cpp 
 	$(CXX) -c $(CXXFLAGS) $< -o $@
@@ -41,4 +40,5 @@ clean-local:
 	rm -f ./$(OBJECTS)
 
 install-exec-local:
-	install ./$(TARGET) $(SYSDIR)/extra
+	$(MKDIR_P) "$(DESTDIR)$(SYSDIR)/extra"
+	$(INSTALL_STRIP_PROGRAM) -m 644 ./$(TARGET) $(DESTDIR)$(SYSDIR)/extra

--- a/tutorial/common.mk
+++ b/tutorial/common.mk
@@ -24,7 +24,7 @@ TARGET = $(NAME).@EXTENSION@
 
 OBJECTS = $(patsubst %.cpp,./%.@OBJEXT@,$(BUILT_SOURCES))
 
-SYSDIR = @SYSDIR@
+EXTDIR = @EXTDIR@
 
 
 # ----------------------------- targets --------------------------------
@@ -40,5 +40,5 @@ clean-local:
 	rm -f ./$(OBJECTS)
 
 install-exec-local:
-	$(MKDIR_P) "$(DESTDIR)$(SYSDIR)/extra"
-	$(INSTALL_STRIP_PROGRAM) -m 644 ./$(TARGET) $(DESTDIR)$(SYSDIR)/extra
+	$(MKDIR_P) "$(DESTDIR)$(EXTDIR)"
+	$(INSTALL_STRIP_PROGRAM) -m 644 ./$(TARGET) $(DESTDIR)$(EXTDIR)


### PR DESCRIPTION
these are the remaining parts of #53 that for whatever reasons did not get included (most likely because i did not properly push them)

- fix out-of-tree building of the `tutorial/`
  - also strip on install, rather than hardcode invocation of `strip` (which doesn't work in cross-build environments)
  - also fix the installation path when running `make install` for the tutorials (previously this would error out); this can be set with the new `--with-externalsdir` flag
  - also honour `$(DESTDIR)` when running `make install` for the tutorials (previously this would attempt to install into `/`)
  (I don't know whether `make install` is actually a use case of the tutorial; however, I'm sure that it shouldn't **fail** the build; since I run the full build-chain when working on the buildsystem, I had to fix this first :-))
- cross-compiling
  - use `AC_CHECK_HEADER` resp `AC_CHECK_LIB` to check for headers resp libraries, instead of just doing an `AC_CHECK_FILE` which  [cannot be used when cross-compiling](https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Files.html)
- configure.ac cleanup
  - reorganize configure.ac slightly so we can use the result of `AC_CANONICAL_HOST` rather than continuously calling `uname -s` (which doesn't work with cross-building anyhow)
  - configure.ac: use `AS_IF` and `AS_CASE` rather than manually running `if`-chains
- add a `--with-extension` flag to configure to allow overriding the autodetected extension (e.g. when compiling for different architetures (amd64,...) and wanting to install them side-by-side; and we need different extensions of Pd64)
- finally support a new system `pd64` which builds Pd-double binaries
  - the dylib is called libflext-pd64 as discussed in #54 
  - there's a new `pd64-flext.pc` pkg-config file (with all the correct flags and switches)
  - no attempt is made to correctly guess the extension of Pd64 externals; we rely on the user to properly use `--with-extension` for that


- Closes: #54 